### PR TITLE
fix: return str value status.SUCCESS.value and update tests

### DIFF
--- a/status_pusher.py
+++ b/status_pusher.py
@@ -63,7 +63,7 @@ class StatusRecord:
 
     value: Optional[float] = None
     epoch_ts: datetime.datetime = datetime.datetime.now().astimezone().timestamp()
-    status: Status = Status.UNKNOWN
+    status: Status = Status.UNKNOWN.value
 
 
 def git_clone(git_url: str, git_branch: str, git_dir, depth=10) -> git.Repo:
@@ -367,11 +367,11 @@ def cli(
 
         # handle success/failure criteria
         ctx.obj.status = (
-            Status.SUCCESS
+            Status.SUCCESS.value
             if ConditionComparitor[success_condition].value(
                 ctx.obj.value, success_value
             )
-            else Status.FAILED
+            else Status.FAILED.value
         )
         logger.debug(
             f"Computed {ConditionComparitor[success_condition].value}"

--- a/test/test_status_pusher.py
+++ b/test/test_status_pusher.py
@@ -369,7 +369,7 @@ def test_promq_cli(git_repo: Repo, repo_path: PosixPath, tmp_path: PosixPath):
     mock_prom_qry.assert_called_with(query=mock_query)
 
     # assert status record SUCCESS
-    assert status_record.status == sp.Status.SUCCESS
+    assert status_record.status == "success"
 
     # assert status value 1.0
     assert status_record.value == 1.0
@@ -450,7 +450,7 @@ def test_influxq_cli(
     assert actual_result.exit_code == 0
 
     # assert status record SUCCESS
-    assert status_record.status == sp.Status.SUCCESS
+    assert status_record.status == "success"
 
     # assert status value 1.0
     assert status_record.value == 1.0


### PR DESCRIPTION
(logs were getting the str repr "status.SUCCESS")